### PR TITLE
Update packages to latest and create database test fixture

### DIFF
--- a/src/Eshopworld.Data.CosmosDb/DocumentDBRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/DocumentDBRepository.cs
@@ -23,10 +23,10 @@ namespace Eshopworld.Data.CosmosDb
             _collectionId = collectionId;
             Client = new DocumentClient(new Uri(endpoint), authKey); // Todo: Implement direct TCP connectivity.
             CreateDatabaseIfNotExistsAsync().Wait();
-            CreateCollectionIfNotExistsAsync(1000).Wait();
+            CreateCollectionIfNotExistsAsync(400).Wait();
             // Todo: Consider performance-tuning: https://docs.microsoft.com/en-us/azure/cosmos-db/performance-tips
         }
-
+        
         public virtual async Task<Document> CreateItemAsync(T item)
         {
             return await Client.CreateDocumentAsync(UriFactory.CreateDocumentCollectionUri(_databaseId, _collectionId),

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/CosmosDbFixture.cs
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/CosmosDbFixture.cs
@@ -1,0 +1,31 @@
+﻿namespace Eshopworld.Data.CosmosDb.Tests
+{
+    using System;
+    using Microsoft.Azure.Documents.Client;
+
+    /// <summary>
+    /// Using a XUnit Fixture allows for a one time create and dispose of resources for the integration test when a class is annotated with an appropriate collection definition
+    /// </summary>
+    public class CosmosDbFixture : IDisposable
+    {
+        //todo these should come from a keyvault so they can be tested locally and remotely.
+        private readonly string endPoint = Environment.GetEnvironmentVariable("endPoint");
+        private readonly string authKey = Environment.GetEnvironmentVariable("authKey");
+        private readonly string databaseId = Environment.GetEnvironmentVariable("databaseId");
+        private readonly string collectionId = Environment.GetEnvironmentVariable("collectionId");
+
+        public CosmosDbFixture()
+        {
+            DocumentDbRepository = new DocumentDBRepository<Dummy>();
+            DocumentDbRepository.Initialize(endPoint, authKey, databaseId, collectionId);
+        }
+
+        internal readonly DocumentDBRepository<Dummy> DocumentDbRepository;
+
+        public void Dispose()
+        {
+            DocumentDbRepository.Client.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(databaseId)).Wait();
+            DocumentDbRepository.Client?.Dispose();
+        }
+    }
+}

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/DatabaseCollection.cs
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/DatabaseCollection.cs
@@ -1,0 +1,13 @@
+﻿namespace Eshopworld.Data.CosmosDb.Tests
+{
+    using Xunit;
+
+    /// <summary>
+    /// Need the definition to wire the collection to the fixture
+    /// </summary>
+    [CollectionDefinition("Database Collection")]
+    public class DatabaseCollection : ICollectionFixture<CosmosDbFixture>
+    {
+
+    }
+}

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/DatabaseCollection.cs
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/DatabaseCollection.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Need the definition to wire the collection to the fixture
     /// </summary>
-    [CollectionDefinition("Database Collection")]
+    [CollectionDefinition(nameof(DatabaseCollection))]
     public class DatabaseCollection : ICollectionFixture<CosmosDbFixture>
     {
 

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/DocumentDBRepositoryTests.cs
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/DocumentDBRepositoryTests.cs
@@ -11,7 +11,7 @@ namespace Eshopworld.Data.CosmosDb.Tests
     /// <summary>
     /// Document Repository Tests and Collection to create just a single collection for each test run and dispose when complete 
     /// </summary>
-    [Collection("Database Collection")]
+    [Collection(nameof(DatabaseCollection))]
     public class DocumentDBRepositoryTests
     {
         private readonly DocumentDBRepository<Dummy> _documentDBRepository;

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/DocumentDBRepositoryTests.cs
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/DocumentDBRepositoryTests.cs
@@ -8,26 +8,18 @@ using Xunit;
 
 namespace Eshopworld.Data.CosmosDb.Tests
 {
+    /// <summary>
+    /// Document Repository Tests and Collection to create just a single collection for each test run and dispose when complete 
+    /// </summary>
+    [Collection("Database Collection")]
     public class DocumentDBRepositoryTests
     {
-        public DocumentDBRepositoryTests()
-        {
-            //todo these should come from a keyvault so they can be tested locally and remotely.
-            var endPoint = Environment.GetEnvironmentVariable("endPoint");
-            var authKey = Environment.GetEnvironmentVariable("authKey");
-            var databaseId = Environment.GetEnvironmentVariable("databaseId");
-            var collectionId = Environment.GetEnvironmentVariable("collectionId");
-
-            _documentDBRepository = new DocumentDBRepository<Dummy>();
-            _documentDBRepository.Initialize(endPoint, authKey, databaseId, collectionId);
-        }
-
-        public void Dispose()
-        {
-            _documentDBRepository.Client?.Dispose();
-        }
-
         private readonly DocumentDBRepository<Dummy> _documentDBRepository;
+
+        public DocumentDBRepositoryTests(CosmosDbFixture fixture)
+        {
+            _documentDBRepository = fixture.DocumentDbRepository;
+        }
 
         [Fact]
         public void ItemIsCreated()

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/Eshopworld.Data.CosmosDb.Tests.csproj
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/Eshopworld.Data.CosmosDb.Tests.csproj
@@ -110,6 +110,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CosmosDbFixture.cs" />
+    <Compile Include="DatabaseCollection.cs" />
     <Compile Include="DocumentDBRepositoryTests.cs" />
     <Compile Include="Dummy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
* Added a database fixture to just create the database once and delete once per collection test execution.
* Dropped the collection default RU count down to the lowest allowed.
* Delete database after collection execution has completed.

I've asked devops to create a RG, Cosmsdb Account and Keyvault for the this type of thing. When they're created next week I'll swing back and update this code to use the credentials in keyvault and update the CI Pipeline too.