### PR TITLE
#72200 - extended the contract for DB configuration registration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ A CosmosDb abstraction layer which follows company established practices.
 
 In your `Program.cs` file
 ```c#
-public static async Task Main()
+public static async Task Main ()
 {
-    var configuration = EswDevOpsSdk.BuildConfiguration(env.ContentRootPath, env.EnvironmentName);
+    var configuration = EswDevOpsSdk.BuildConfiguration (env.ContentRootPath, env.EnvironmentName);
 
-    var builder = new ContainerBuilder();
+    var builder = new ContainerBuilder ();
 
-    builder.RegisterModule<CosmosDbModule>();
-    builder.ConfigureCosmosDb(_configuration);
+    builder.RegisterModule<CosmosDbModule> ();
+    builder.ConfigureCosmosDb (_configuration, "MyConfigurationSectionKey", "MyOptionalConnectionStringKey");
 
-    using (builder.Build())
+    using (builder.Build ())
     {
-        await Task.Delay(Timeout.Infinite);
+        await Task.Delay (Timeout.Infinite);
     }
 }
 ```
@@ -30,28 +30,21 @@ In your `Startup.cs` file
 ```c#
 private readonly IConfigurationRoot _configuration;
 
-public Startup(IConfiguration configuration, IWebHostEnvironment env)
+public Startup (IConfiguration configuration, IWebHostEnvironment env)
 {
-    _configuration = EswDevOpsSdk.BuildConfiguration(env.ContentRootPath, env.EnvironmentName);
+    _configuration = EswDevOpsSdk.BuildConfiguration (env.ContentRootPath, env.EnvironmentName);
 }
 
-public void ConfigureContainer(ContainerBuilder builder)
+public void ConfigureContainer (ContainerBuilder builder)
 {
-    builder.RegisterModule<CosmosDbModule>();
-    builder.ConfigureCosmosDb(_configuration);
+    builder.RegisterModule<CosmosDbModule> ();
+    builder.ConfigureCosmosDb (_configuration, "MyConfigurationSectionKey", "MyOptionalConnectionStringKey");
 }
 ```
 
 ## Configuration
 
-Regardless of where your configuration is stored, this is the structure you need to have in place in 
-order to be able to correctly retrieve Cosmos DB settings.
+The configuration is defined by two parts:
+- a structure representing all the settings (represented by `CosmosDbConfiguration` class)
+- optionally, if database URI and secret key are not explicitly provided in configuration section, the connection string stored in the configuration (referenced via connection string key) will be used to retrieve the relevant details 
 
-`CosmosDB:ConnectionString` holding a valid Cosmos DB connection string
-
-or
-
-`DbConfiguration:DatabaseEndpoint` Cosmos DB database endpoint
-`DbConfiguration:DatabaseKey` Cosmos DB database key
-`DbConfiguration:Throughput` Throughput (optional, defaults to 400 RUs)
-`DbConfiguration:DefaultTimeToLive` TTL (optional)

--- a/src/Eshopworld.Data.CosmosDb.sln
+++ b/src/Eshopworld.Data.CosmosDb.sln
@@ -7,7 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eshopworld.Data.CosmosDb", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{3FC28000-66E4-487A-9E8D-4A4F8146C418}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eshopworld.Data.CosmosDb.Tests", "Tests\Eshopworld.Data.CosmosDb.Tests\Eshopworld.Data.CosmosDb.Tests.csproj", "{0DBFBD5D-C034-4C86-A0D1-02CE0210922D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eshopworld.Data.CosmosDb.Tests", "Tests\Eshopworld.Data.CosmosDb.Tests\Eshopworld.Data.CosmosDb.Tests.csproj", "{0DBFBD5D-C034-4C86-A0D1-02CE0210922D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6EBAC030-B6CF-459F-AD48-09042B33B5EE}"
+	ProjectSection(SolutionItems) = preProject
+		..\README.md = ..\README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Eshopworld.Data.CosmosDb/ConfigurationParser.cs
+++ b/src/Eshopworld.Data.CosmosDb/ConfigurationParser.cs
@@ -1,5 +1,4 @@
 ﻿using System.Data.Common;
-using System.Diagnostics.CodeAnalysis;
 using Eshopworld.Data.CosmosDb.Exceptions;
 using Microsoft.Extensions.Configuration;
 
@@ -11,20 +10,18 @@ namespace Eshopworld.Data.CosmosDb
     /// Will throw a <see cref="CosmosDbConfigurationException"/> if cannot correctly parse connection string
     /// </remarks>
     /// </summary>
-    public static class ConfigurationParser
+    internal static class ConfigurationParser
     {
-        private const string ConnectionStringKey = "CosmosDB:ConnectionString";
-
         private const string EndPointKey = "AccountEndpoint";
 
         private const string AccountKey = "AccountKey";
 
-        public static (string dbEndpoint, string dbKey) GetCosmosSettings(IConfiguration configuration, string connectionStringKey = ConnectionStringKey)
+        public static (string dbEndpoint, string dbKey) GetCosmosSettings(IConfiguration configuration, string connectionStringKey)
         {
             var connectionString = configuration[connectionStringKey];
             if (string.IsNullOrEmpty(connectionString))
             {
-                throw new CosmosDbConfigurationException("Missing connection string");
+                throw new CosmosDbConfigurationException($"Missing connection string for key '{connectionStringKey}'");
             }
 
             var connectionStringBuilder = new DbConnectionStringBuilder { ConnectionString = connectionString };

--- a/src/Eshopworld.Data.CosmosDb/CosmosDbCollectionSettings.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbCollectionSettings.cs
@@ -2,13 +2,24 @@
 {
     public class CosmosDbCollectionSettings
     {
+        /// <summary>
+        /// Defines collection name. Collection will be created if does not exist
+        /// </summary>
         public string CollectionName { get; set; }
+
+        /// <summary>
+        /// Defines partition key. Has no effect for an existing collection
+        /// </summary>
         public string PartitionKey { get; set; }
+
+        /// <summary>
+        /// List of unique constrain keys defined on the document fields
+        /// </summary>
         public string[] UniqueKeys { get; set; }
 
         // default constructor needed
-        public CosmosDbCollectionSettings() : this(null) { }
-        public CosmosDbCollectionSettings(string collectionName)
+        public CosmosDbCollectionSettings () : this (null) { }
+        public CosmosDbCollectionSettings (string collectionName)
         {
             CollectionName = collectionName;
         }

--- a/src/Eshopworld.Data.CosmosDb/CosmosDbConfiguration.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbConfiguration.cs
@@ -5,9 +5,24 @@ namespace Eshopworld.Data.CosmosDb
 {
     public class CosmosDbConfiguration
     {
+        /// <summary>
+        /// Defines the URI for the cosmos DB account
+        /// </summary>
         public string DatabaseEndpoint { get; set; }
+
+        /// <summary>
+        /// Defines a key for the account
+        /// </summary>
         public string DatabaseKey { get; set; }
+
+        /// <summary>
+        /// Defines a throughput for the databases and collections
+        /// </summary>
         public int Throughput { get; set; } = 400;
+
+        /// <summary>
+        /// Defines TTL on database level
+        /// </summary>
         public int? DefaultTimeToLive { get; set; }
 
         /// <summary>

--- a/src/Eshopworld.Data.CosmosDb/Extensions/ContainerBuilderExtensions.cs
+++ b/src/Eshopworld.Data.CosmosDb/Extensions/ContainerBuilderExtensions.cs
@@ -3,21 +3,31 @@ using Microsoft.Extensions.Configuration;
 
 namespace Eshopworld.Data.CosmosDb.Extensions
 {
-    public static class ContainerBuilderExtensions
+    public static class ContainerBuilderCosmosExtensions
     {
-        private const string DbConfigurationSection = "DbConfiguration";
+        private const string DefaultConfigurationSection = "DbConfiguration";
+
+        private const string DefaultConnectionStringKey = "CosmosDB:ConnectionString";
 
         /// <summary>
         /// Configures Cosmos DB from existing config store.
         /// </summary>
-        public static ContainerBuilder ConfigureCosmosDb(this ContainerBuilder builder, IConfiguration configuration)
+        /// <param name="builder">Extension of a builder</param>
+        /// <param name="configuration">Instance of the configuration holding the database settings</param>
+        /// <param name="configurationSectionKey">Optional key for entire configuration section</param>
+        /// <param name="connectionStringKey">Optional key for connection string entry in the configuration.
+        /// If database URI and key are not provided as part of the configuration section,
+        /// connectionStringKey can be specified to retrieve the database URI and key.
+        /// The key is ignored configuration section contains the right settings</param>
+        public static ContainerBuilder ConfigureCosmosDb (this ContainerBuilder builder, IConfiguration configuration, 
+            string configurationSectionKey = DefaultConfigurationSection, string connectionStringKey = null)
         {
-            var cosmosDbConfiguration = configuration.GetSection(DbConfigurationSection).Get<CosmosDbConfiguration>() ?? new CosmosDbConfiguration();
-            var hasCosmosConnectionDetails = cosmosDbConfiguration.HasCosmosEndpointAndKey();
+            var cosmosDbConfiguration = configuration.GetSection (configurationSectionKey).Get<CosmosDbConfiguration>() ?? new CosmosDbConfiguration();
+            var hasCosmosConnectionDetails = cosmosDbConfiguration.HasCosmosEndpointAndKey ();
 
             if (!hasCosmosConnectionDetails)
             {
-                var (dbEndpoint, dbKey) = ConfigurationParser.GetCosmosSettings(configuration);
+                var (dbEndpoint, dbKey) = ConfigurationParser.GetCosmosSettings(configuration, connectionStringKey ?? DefaultConnectionStringKey);
                 cosmosDbConfiguration.DatabaseEndpoint = dbEndpoint;
                 cosmosDbConfiguration.DatabaseKey = dbKey;
             }


### PR DESCRIPTION
The package does not allow to specify the db connection string key name nor the config section key name, This has been resolved as part of the PR now plus readme file is updated