### PR TITLE
Enable CosmosClient options

### DIFF
--- a/src/Eshopworld.Data.CosmosDb/CosmosDbClientFactory.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbClientFactory.cs
@@ -80,7 +80,7 @@ namespace Eshopworld.Data.CosmosDb
 
             lock (_sync)
             {
-                _client.Dispose();
+                _client?.Dispose();
                 _client = null;
             }
         }

--- a/src/Eshopworld.Data.CosmosDb/CosmosDbClientFactory.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbClientFactory.cs
@@ -20,7 +20,7 @@ namespace Eshopworld.Data.CosmosDb
             _bb = bb ?? throw new ArgumentNullException(nameof(bb));
         }
 
-        public CosmosClient InitialiseClient(CosmosDbConfiguration config)
+        public CosmosClient InitialiseClient(CosmosDbConfiguration config, CosmosClientOptions clientOptions = null)
         {
             if (_client != null) return _client;
 
@@ -32,7 +32,7 @@ namespace Eshopworld.Data.CosmosDb
             {
                 if (_client != null) return _client;
 
-                var client = new CosmosClient(config.DatabaseEndpoint, config.DatabaseKey);
+                var client = new CosmosClient(config.DatabaseEndpoint, config.DatabaseKey, clientOptions);
                 foreach (var (databaseName, containerSettings) in config.Databases)
                 {
                     CreateDatabaseIfNotExistsAsync(config, client, databaseName, containerSettings).Wait();

--- a/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
@@ -39,7 +39,7 @@ namespace Eshopworld.Data.CosmosDb
 
         public Container DbContainer => _container ??= DbClient.GetContainer(_databaseId, _containerName);
 
-        public CosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions)
+        public ICosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions)
         {
             if(_dbClient != null)
             {
@@ -51,7 +51,7 @@ namespace Eshopworld.Data.CosmosDb
             return this;
         }
 
-        public CosmosDbRepository UseCollection(string collectionName, string databaseId = null)
+        public ICosmosDbRepository UseCollection(string collectionName, string databaseId = null)
         {
             if (databaseId != null && !_dbSetup.Databases.ContainsKey(databaseId))
                 throw new ArgumentException($"The database id '{databaseId}' is not configured");

--- a/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
@@ -41,6 +41,11 @@ namespace Eshopworld.Data.CosmosDb
 
         public CosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions)
         {
+            if(_dbClient != null)
+            {
+                InvalidateClient();
+            }
+
             _clientOptions = clientOptions;
 
             return this;

--- a/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
@@ -20,7 +20,8 @@ namespace Eshopworld.Data.CosmosDb
 
         private CosmosClient _dbClient;
         private Container _container;
-        private CosmosClientOptions _clientOptions = null;
+
+        public CosmosClientOptions CosmosClientOptions { get; set; }
 
         public CosmosDbRepository(
             CosmosDbConfiguration setup,
@@ -35,23 +36,11 @@ namespace Eshopworld.Data.CosmosDb
                 UseCollection(collectionName, dbId);
         }
 
-        private CosmosClient DbClient => _dbClient ??= _clientFactory.InitialiseClient(_dbSetup, _clientOptions);
+        private CosmosClient DbClient => _dbClient ??= _clientFactory.InitialiseClient(_dbSetup, CosmosClientOptions);
 
         public Container DbContainer => _container ??= DbClient.GetContainer(_databaseId, _containerName);
 
-        public ICosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions)
-        {
-            if(_dbClient != null)
-            {
-                InvalidateClient();
-            }
-
-            _clientOptions = clientOptions;
-
-            return this;
-        }
-
-        public ICosmosDbRepository UseCollection(string collectionName, string databaseId = null)
+        public void UseCollection(string collectionName, string databaseId = null)
         {
             if (databaseId != null && !_dbSetup.Databases.ContainsKey(databaseId))
                 throw new ArgumentException($"The database id '{databaseId}' is not configured");
@@ -63,8 +52,6 @@ namespace Eshopworld.Data.CosmosDb
                     $"The collection '{collectionName}' is not configured for '{_databaseId}' database");
 
             _containerName = collectionName;
-
-            return this;
         }
 
         public async Task<DocumentContainer<T>> CreateAsync<T>(T data)

--- a/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
@@ -20,8 +20,16 @@ namespace Eshopworld.Data.CosmosDb
 
         private CosmosClient _dbClient;
         private Container _container;
+        private CosmosClientOptions _cosmosClientOptions = null;
 
-        public CosmosClientOptions CosmosClientOptions { get; set; }
+        public CosmosClientOptions CosmosClientOptions 
+        { 
+            set
+            {
+                _cosmosClientOptions = value;
+                InvalidateClient();
+            }
+        }
 
         public CosmosDbRepository(
             CosmosDbConfiguration setup,
@@ -36,7 +44,7 @@ namespace Eshopworld.Data.CosmosDb
                 UseCollection(collectionName, dbId);
         }
 
-        private CosmosClient DbClient => _dbClient ??= _clientFactory.InitialiseClient(_dbSetup, CosmosClientOptions);
+        private CosmosClient DbClient => _dbClient ??= _clientFactory.InitialiseClient(_dbSetup, _cosmosClientOptions);
 
         public Container DbContainer => _container ??= DbClient.GetContainer(_databaseId, _containerName);
 

--- a/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
@@ -20,6 +20,7 @@ namespace Eshopworld.Data.CosmosDb
 
         private CosmosClient _dbClient;
         private Container _container;
+        private CosmosClientOptions _clientOptions = null;
 
         public CosmosDbRepository(
             CosmosDbConfiguration setup,
@@ -34,11 +35,18 @@ namespace Eshopworld.Data.CosmosDb
                 UseCollection(collectionName, dbId);
         }
 
-        private CosmosClient DbClient => _dbClient ??= _clientFactory.InitialiseClient(_dbSetup);
+        private CosmosClient DbClient => _dbClient ??= _clientFactory.InitialiseClient(_dbSetup, _clientOptions);
 
         public Container DbContainer => _container ??= DbClient.GetContainer(_databaseId, _containerName);
 
-        public void UseCollection(string collectionName, string databaseId = null)
+        public CosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions)
+        {
+            _clientOptions = clientOptions;
+
+            return this;
+        }
+
+        public CosmosDbRepository UseCollection(string collectionName, string databaseId = null)
         {
             if (databaseId != null && !_dbSetup.Databases.ContainsKey(databaseId))
                 throw new ArgumentException($"The database id '{databaseId}' is not configured");
@@ -50,6 +58,8 @@ namespace Eshopworld.Data.CosmosDb
                     $"The collection '{collectionName}' is not configured for '{_databaseId}' database");
 
             _containerName = collectionName;
+
+            return this;
         }
 
         public async Task<DocumentContainer<T>> CreateAsync<T>(T data)

--- a/src/Eshopworld.Data.CosmosDb/Eshopworld.Data.CosmosDb.csproj
+++ b/src/Eshopworld.Data.CosmosDb/Eshopworld.Data.CosmosDb.csproj
@@ -5,8 +5,8 @@
     <PackageId>Eshopworld.Data.CosmosDb</PackageId>
 	  <PackageIcon>icon.png</PackageIcon>
     <Description>Cosmos DB CRUD functionality</Description>
-    <Version>3.0.2</Version>
-    <PackageReleaseNotes>Upgrade of dependency packages.</PackageReleaseNotes>
+    <Version>3.0.3-preview1</Version>
+    <PackageReleaseNotes>Enable CosmosClient options.</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <DebugType>Portable</DebugType>
     <IncludeSource>True</IncludeSource>

--- a/src/Eshopworld.Data.CosmosDb/Eshopworld.Data.CosmosDb.csproj
+++ b/src/Eshopworld.Data.CosmosDb/Eshopworld.Data.CosmosDb.csproj
@@ -5,7 +5,7 @@
     <PackageId>Eshopworld.Data.CosmosDb</PackageId>
 	  <PackageIcon>icon.png</PackageIcon>
     <Description>Cosmos DB CRUD functionality</Description>
-    <Version>3.0.3-preview1</Version>
+    <Version>3.0.3-preview.2</Version>
     <PackageReleaseNotes>Enable CosmosClient options.</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <DebugType>Portable</DebugType>

--- a/src/Eshopworld.Data.CosmosDb/Eshopworld.Data.CosmosDb.csproj
+++ b/src/Eshopworld.Data.CosmosDb/Eshopworld.Data.CosmosDb.csproj
@@ -5,7 +5,7 @@
     <PackageId>Eshopworld.Data.CosmosDb</PackageId>
 	  <PackageIcon>icon.png</PackageIcon>
     <Description>Cosmos DB CRUD functionality</Description>
-    <Version>3.0.3-preview.2</Version>
+    <Version>3.0.3</Version>
     <PackageReleaseNotes>Enable CosmosClient options.</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <DebugType>Portable</DebugType>

--- a/src/Eshopworld.Data.CosmosDb/ICosmosDbClientFactory.cs
+++ b/src/Eshopworld.Data.CosmosDb/ICosmosDbClientFactory.cs
@@ -10,8 +10,9 @@ namespace Eshopworld.Data.CosmosDb
         /// When calling for already cached client, the settings has no effect and previously cached version is returned.
         /// </summary>
         /// <param name="config">Database and collection settings</param>
+        /// <param name="clientOptions">Cosmos DB client options </param>
         /// <returns>Instance of a db client</returns>
-        CosmosClient InitialiseClient(CosmosDbConfiguration config);
+        CosmosClient InitialiseClient(CosmosDbConfiguration config, CosmosClientOptions clientOptions);
 
         /// <summary>
         /// If any client is cached, this will invalidate (dispose) the client connection and subsequent call to InitialiseClient

--- a/src/Eshopworld.Data.CosmosDb/ICosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/ICosmosDbRepository.cs
@@ -14,13 +14,13 @@ namespace Eshopworld.Data.CosmosDb
         /// Defines the collection (and from which database) that should be used by the repository.
         /// </summary>
         /// <exception cref="ArgumentException">When the collection name or database id is incorrect</exception>
-        CosmosDbRepository UseCollection(string collectionName, string databaseId = null);
+        ICosmosDbRepository UseCollection(string collectionName, string databaseId = null);
 
         /// <summary>
         /// Defines the CosmosClient options for this client.
         /// </summary>
         /// <exception cref="ArgumentException">When the collection name or database id is incorrect</exception>
-        CosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions);
+        ICosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions);
 
         /// <summary>
         /// Creates new instance of a document in the database.

--- a/src/Eshopworld.Data.CosmosDb/ICosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/ICosmosDbRepository.cs
@@ -14,13 +14,7 @@ namespace Eshopworld.Data.CosmosDb
         /// Defines the collection (and from which database) that should be used by the repository.
         /// </summary>
         /// <exception cref="ArgumentException">When the collection name or database id is incorrect</exception>
-        ICosmosDbRepository UseCollection(string collectionName, string databaseId = null);
-
-        /// <summary>
-        /// Defines the CosmosClient options for this client.
-        /// </summary>
-        /// <exception cref="ArgumentException">When the collection name or database id is incorrect</exception>
-        ICosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions);
+        void UseCollection(string collectionName, string databaseId = null);
 
         /// <summary>
         /// Creates new instance of a document in the database.

--- a/src/Eshopworld.Data.CosmosDb/ICosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/ICosmosDbRepository.cs
@@ -14,7 +14,13 @@ namespace Eshopworld.Data.CosmosDb
         /// Defines the collection (and from which database) that should be used by the repository.
         /// </summary>
         /// <exception cref="ArgumentException">When the collection name or database id is incorrect</exception>
-        void UseCollection(string collectionName, string databaseId = null);
+        CosmosDbRepository UseCollection(string collectionName, string databaseId = null);
+
+        /// <summary>
+        /// Defines the CosmosClient options for this client.
+        /// </summary>
+        /// <exception cref="ArgumentException">When the collection name or database id is incorrect</exception>
+        CosmosDbRepository UseCosmosClientOptions(CosmosClientOptions clientOptions);
 
         /// <summary>
         /// Creates new instance of a document in the database.

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/CosmosDbRepositoryTests.cs
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/CosmosDbRepositoryTests.cs
@@ -48,7 +48,7 @@ namespace Eshopworld.Data.CosmosDb.Tests
 
             var clientFactoryMock = new Mock<ICosmosDbClientFactory>();
             clientFactoryMock
-                .Setup(x => x.InitialiseClient(configuration))
+                .Setup(x => x.InitialiseClient(configuration, null))
                 .Returns(clientMock.Object)
                 .Verifiable();
 

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/CosmosDbRepositoryTests.cs
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/CosmosDbRepositoryTests.cs
@@ -19,6 +19,7 @@ namespace Eshopworld.Data.CosmosDb.Tests
         private readonly CosmosDbRepository _repository;
         private readonly Mock<ItemResponse<TestData>> _responseMock;
         private readonly Mock<Container> _containerMock;
+        private readonly Mock<ICosmosDbClientFactory> _clientFactoryMock;
 
         public CosmosDbRepositoryTests()
         {
@@ -46,13 +47,28 @@ namespace Eshopworld.Data.CosmosDb.Tests
                 .Returns(_containerMock.Object)
                 .Verifiable();
 
-            var clientFactoryMock = new Mock<ICosmosDbClientFactory>();
-            clientFactoryMock
-                .Setup(x => x.InitialiseClient(configuration, null))
+            _clientFactoryMock = new Mock<ICosmosDbClientFactory>();
+            _clientFactoryMock
+                .Setup(x => x.InitialiseClient(configuration, It.IsAny<CosmosClientOptions>()))
                 .Returns(clientMock.Object)
                 .Verifiable();
 
-            _repository = new CosmosDbRepository(configuration, clientFactoryMock.Object, bigBrother);
+            _repository = new CosmosDbRepository(configuration, _clientFactoryMock.Object, bigBrother);
+        }
+
+        [Fact]
+        [IsUnit]
+        public void WhenCosmosClientOptionsIsSet_ThenFactoryInitialiseClientIsCalled()
+        {
+            // Arrange
+            var options = new CosmosClientOptions();
+
+            // Act
+            _repository.CosmosClientOptions = options;
+            var dbContainer = _repository.DbContainer;
+
+            // Assert
+            _clientFactoryMock.Verify(x => x.InitialiseClient(It.IsAny<CosmosDbConfiguration>(), options));
         }
 
         [Fact]


### PR DESCRIPTION
Enable user to specify CosmosClient options.

CosmosClient options allow the user to set further options like:
- use custom JSON serializer
- add custom JSON coverters (for example to handle polymorphic types)
- specify serialization options (for example camelCase serialization)

This PR is on preview version as it's been published to allow to continue working on Captain Hook. It will be moved out of preview **once approved and before merging**.