### PR TITLE
#100460: Create 'GetById' method in 'data-cosmos-db' package

### DIFF
--- a/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/CosmosDbRepository.cs
@@ -117,6 +117,16 @@ namespace Eshopworld.Data.CosmosDb
             return QueryInternalAsync<T>(cosmosQueryDef);
         }
 
+        public async Task<DocumentContainer<T>> GetByIdAsync<T>(string id, string partitionKey)
+        {
+            return await ExecuteFunction(async () =>
+            {
+               var itemResponse = await DbContainer.ReadItemAsync<T>(id, new PartitionKey(partitionKey));
+
+               return MapResponse(itemResponse);
+            });
+        }
+
         private async Task<IEnumerable<T>> QueryInternalAsync<T>(CosmosQuery cosmosQueryDef)
         {
             return await ExecuteFunction(async () =>

--- a/src/Eshopworld.Data.CosmosDb/Eshopworld.Data.CosmosDb.csproj
+++ b/src/Eshopworld.Data.CosmosDb/Eshopworld.Data.CosmosDb.csproj
@@ -5,8 +5,8 @@
     <PackageId>Eshopworld.Data.CosmosDb</PackageId>
 	  <PackageIcon>icon.png</PackageIcon>
     <Description>Cosmos DB CRUD functionality</Description>
-    <Version>3.0.4</Version>
-    <PackageReleaseNotes>Enable CosmosClient options.</PackageReleaseNotes>
+    <Version>3.0.5</Version>
+    <PackageReleaseNotes>Added Get By Id method.</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <DebugType>Portable</DebugType>
     <IncludeSource>True</IncludeSource>

--- a/src/Eshopworld.Data.CosmosDb/ICosmosDbRepository.cs
+++ b/src/Eshopworld.Data.CosmosDb/ICosmosDbRepository.cs
@@ -69,5 +69,14 @@ namespace Eshopworld.Data.CosmosDb
         /// <param name="cosmosQueryDef">Query definition</param>
         /// <returns>Collection of documents matching given query with extended meta-data for each document</returns>
         Task<IEnumerable<DocumentContainer<T>>> QueryWithContainerAsync<T>(CosmosQuery cosmosQueryDef);
+
+        /// <summary>
+        /// Returns a document by the given identifier
+        /// </summary>
+        /// <typeparam name="T">Type of document data</typeparam>
+        /// <param name="id">The identifier of the document</param>
+        /// <param name="partitionKey"></param>
+        /// <returns></returns>
+        Task<DocumentContainer<T>> GetByIdAsync<T>(string id, string partitionKey);
     }
 }

--- a/src/Tests/Eshopworld.Data.CosmosDb.Tests/CosmosDbRepositoryTests.cs
+++ b/src/Tests/Eshopworld.Data.CosmosDb.Tests/CosmosDbRepositoryTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -278,6 +279,29 @@ namespace Eshopworld.Data.CosmosDb.Tests
 
             // Assert
             func.Should().ThrowExactly<CosmosException>().Which.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        }
+
+        [Fact, IsUnit]
+        public async Task GetByIdAsync_ValidRequest_RetrievesItem()
+        {
+            // Arrange
+            var expectedItem = new TestData();
+            var id = "id";
+            var collectionPartitionKey = "partitionKey";
+            var partitionKey = new PartitionKey(collectionPartitionKey);
+
+            _responseMock
+                .SetupGet(x => x.Resource)
+                .Returns(expectedItem);
+            _containerMock
+                .Setup(x => x.ReadItemAsync<TestData>(id, partitionKey, It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(_responseMock.Object);
+
+            // Act
+            var result = await _repository.GetByIdAsync<TestData>(id, collectionPartitionKey);
+
+            // Assert
+            result.Document.Should().BeSameAs(expectedItem);
         }
     }
 }


### PR DESCRIPTION
Extend the cosmos db package, so we can query the document directly by id